### PR TITLE
Bump loom version to 0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'fabric-loom' version '0.4-SNAPSHOT'
+  id 'fabric-loom' version '0.6-SNAPSHOT'
   id 'maven-publish'
 }
 


### PR DESCRIPTION
Building on JDK 16 requires Gradle 7.0-rc1, and building on both of those requires the loom version to be at least 0.6. 